### PR TITLE
Feat/custom codegen

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,10 +29,12 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'org.postgresql:postgresql:42.7.3'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/scripts/codegen/.env.example
+++ b/scripts/codegen/.env.example
@@ -1,0 +1,5 @@
+PG_DSN=postgresql://user:pass@localhost:5432/mydb
+PG_SCHEMA=public
+JAVA_PACKAGE_BASE=com.example.app
+OUT_JAVA=../java-generated
+ONLY_TABLES=

--- a/scripts/codegen/gen.py
+++ b/scripts/codegen/gen.py
@@ -47,6 +47,9 @@ def to_entity_model(conn, *, package_base: str, schema: str, table: str) -> Enti
         if field.pk:
             id_type = java_type
 
+    for i, f in enumerate(fields):
+        f.last = (i == len(fields) - 1)
+
     return EntityModel(
         package_base=package_base,
         schema=schema,

--- a/scripts/codegen/gen.py
+++ b/scripts/codegen/gen.py
@@ -1,0 +1,119 @@
+import os
+
+import psycopg
+import pystache
+from dotenv import load_dotenv
+
+from introspect_pg import list_tables, list_columns, primary_key_columns, foreign_keys
+from model import EntityModel, FieldModel
+from naming import snake_to_pascal, snake_to_camel, table_to_entity_name, resource_path_v1
+from type_map import pg_to_java
+
+load_dotenv()
+
+
+def render(template_path: str, ctx: dict) -> str:
+    with open(template_path, "r", encoding="utf-8") as f:
+        return pystache.render(f.read(), ctx)
+
+
+def write_file(base_dir: str, package: str, filename: str, content: str) -> None:
+    out_path = os.path.join(base_dir, *package.split("."), filename)
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def to_entity_model(conn, *, package_base: str, schema: str, table: str) -> EntityModel:
+    cols = list_columns(conn, schema, table)
+    pk_set = primary_key_columns(conn, schema, table)
+    fk_map = foreign_keys(conn, schema, table)
+
+    fields = []
+    id_type = "Long"  # fallback
+    for c in cols:
+        java_type = pg_to_java(c.data_type, c.udt_name)
+        field = FieldModel(
+            name=snake_to_camel(c.column_name),
+            column=c.column_name,
+            java_type=java_type,
+            required=(not c.is_nullable),
+            max_len=c.char_max_len,
+            comment=c.comment,
+            pk=(c.column_name in pk_set),
+            fk=fk_map.get(c.column_name),
+        )
+        fields.append(field)
+        if field.pk:
+            id_type = java_type
+
+    return EntityModel(
+        package_base=package_base,
+        schema=schema,
+        table=table,
+        entity_name=table_to_entity_name(table),
+        resource=resource_path_v1(table),
+        id_type=id_type,
+        fields=fields,
+    )
+
+
+def main():
+    # 1) 配置区（你改这里）
+    dsn = os.environ.get("PG_DSN", "postgresql://user:pass@localhost:5432/mydb")
+    schema = os.environ.get("PG_SCHEMA", "public")
+    package_base = os.environ.get("JAVA_PACKAGE_BASE", "com.example.app")
+    out_java = os.environ.get("OUT_JAVA", "./out/src/main/java")
+
+    # 可选：只生成部分表
+    only_tables = os.environ.get("ONLY_TABLES")  # 例如 "users,orders"
+    only = set(t.strip() for t in only_tables.split(",")) if only_tables else None
+
+    templates_dir = os.path.join(os.path.dirname(__file__), "templates")
+
+    with psycopg.connect(dsn) as conn:
+        tables = list_tables(conn, schema)
+        if only:
+            tables = [t for t in tables if t in only]
+
+        for table in tables:
+            model = to_entity_model(conn, package_base=package_base, schema=schema, table=table)
+
+            # 2) 生成文件（示例：CreateDTO + VO）
+            dto_pkg = f"{package_base}.dto"
+            vo_pkg = f"{package_base}.vo"
+            mapper_pkg = f"{package_base}.mapper"
+            controller_pkg = f"{package_base}.controller"
+            service_pkg = f"{package_base}.service"
+
+            create_dto = render(os.path.join(templates_dir, "CreateDTO.mustache"), model.__dict__ | {
+                "fields": [f.__dict__ for f in model.fields]
+            })
+            update_dto = render(os.path.join(templates_dir, "UpdateDTO.mustache"), model.__dict__ | {
+                "fields": [f.__dict__ for f in model.fields]
+            })
+            mapper = render(os.path.join(templates_dir, "Mapper.mustache"), model.__dict__ | {
+                "fields": [f.__dict__ for f in model.fields]
+            })
+            vo = render(os.path.join(templates_dir, "VO.mustache"), model.__dict__ | {
+                "fields": [f.__dict__ for f in model.fields]
+            })
+            controller = render(os.path.join(templates_dir, "Controller.mustache"), model.__dict__ | {
+                "fields": [f.__dict__ for f in model.fields]
+            })
+            service = render(os.path.join(templates_dir, "Service.mustache"), model.__dict__ | {
+                "fields": [f.__dict__ for f in model.fields]
+            })
+
+            write_file(out_java, dto_pkg, f"{model.entity_name}CreateDTO.java", create_dto)
+            write_file(out_java, dto_pkg, f"{model.entity_name}UpdateDTO.java", update_dto)
+            write_file(out_java, mapper_pkg, f"{model.entity_name}Mapper.java", mapper)
+            write_file(out_java, vo_pkg, f"{model.entity_name}VO.java", vo)
+            write_file(out_java, controller_pkg, f"{model.entity_name}Controller.java", controller)
+            write_file(out_java, service_pkg, f"{model.entity_name}Service.java", service)
+
+            print(f"generated: {model.entity_name} (table={table})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/codegen/introspect_pg.py
+++ b/scripts/codegen/introspect_pg.py
@@ -1,0 +1,94 @@
+from dataclasses import dataclass
+from typing import Optional, List, Dict
+import psycopg
+
+@dataclass
+class PgColumn:
+    column_name: str
+    is_nullable: bool
+    data_type: str
+    udt_name: str
+    char_max_len: Optional[int]
+    numeric_precision: Optional[int]
+    numeric_scale: Optional[int]
+    comment: Optional[str]
+
+def list_columns(conn, schema: str, table: str) -> List[PgColumn]:
+    sql = """
+    SELECT
+      c.column_name,
+      (c.is_nullable = 'YES') AS is_nullable,
+      c.data_type,
+      c.udt_name,
+      c.character_maximum_length,
+      c.numeric_precision,
+      c.numeric_scale,
+      pgd.description AS column_comment
+    FROM information_schema.columns c
+    LEFT JOIN pg_catalog.pg_statio_all_tables st
+      ON st.schemaname = c.table_schema AND st.relname = c.table_name
+    LEFT JOIN pg_catalog.pg_description pgd
+      ON pgd.objoid = st.relid AND pgd.objsubid = c.ordinal_position
+    WHERE c.table_schema = %s AND c.table_name = %s
+    ORDER BY c.ordinal_position;
+    """
+    rows = conn.execute(sql, (schema, table)).fetchall()
+    return [
+        PgColumn(
+            column_name=r[0],
+            is_nullable=r[1],
+            data_type=r[2],
+            udt_name=r[3],
+            char_max_len=r[4],
+            numeric_precision=r[5],
+            numeric_scale=r[6],
+            comment=r[7],
+        )
+        for r in rows
+    ]
+
+def primary_key_columns(conn, schema: str, table: str) -> set[str]:
+    # 用 regclass 要 schema-qualified
+    sql = """
+    SELECT a.attname AS column_name
+    FROM pg_index i
+    JOIN pg_class  c ON c.oid = i.indrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+    WHERE i.indisprimary
+      AND n.nspname = %s
+      AND c.relname = %s;
+    """
+    rows = conn.execute(sql, (schema, table)).fetchall()
+    return {r[0] for r in rows}
+
+def foreign_keys(conn, schema: str, table: str) -> Dict[str, Dict[str, str]]:
+    sql = """
+    SELECT
+      kcu.column_name,
+      ccu.table_name AS foreign_table_name,
+      ccu.column_name AS foreign_column_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+    JOIN information_schema.constraint_column_usage ccu
+      ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+    WHERE tc.constraint_type = 'FOREIGN KEY'
+      AND tc.table_schema = %s
+      AND tc.table_name = %s;
+    """
+    rows = conn.execute(sql, (schema, table)).fetchall()
+    out: Dict[str, Dict[str, str]] = {}
+    for col, ft, fc in rows:
+        out[col] = {"table": ft, "column": fc}
+    return out
+
+def list_tables(conn, schema: str) -> List[str]:
+    sql = """
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE table_schema = %s AND table_type='BASE TABLE'
+    ORDER BY table_name;
+    """
+    rows = conn.execute(sql, (schema,)).fetchall()
+    return [r[0] for r in rows]

--- a/scripts/codegen/model.py
+++ b/scripts/codegen/model.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Optional, List, Dict
+
+@dataclass
+class FieldModel:
+    name: str                 # java字段名，如 userName
+    column: str               # 原列名，如 user_name
+    java_type: str            # String/Long/UUID...
+    required: bool            # NOT NULL
+    max_len: Optional[int]    # varchar长度
+    comment: Optional[str]    # 列注释
+    pk: bool = False
+    fk: Optional[Dict[str, str]] = None  # {"table": "...", "column": "..."}
+
+@dataclass
+class EntityModel:
+    package_base: str
+    schema: str
+    table: str
+    entity_name: str          # 类名：UserAccount
+    resource: str             # 路径/权限资源名：/v1/ai_models
+    id_type: str              # Long/UUID/...
+    fields: List[FieldModel]

--- a/scripts/codegen/naming.py
+++ b/scripts/codegen/naming.py
@@ -1,0 +1,35 @@
+import re
+
+def snake_to_pascal(name: str) -> str:
+    parts = re.split(r"[_\s]+", name.strip())
+    return "".join(p[:1].upper() + p[1:] for p in parts if p)
+
+def snake_to_camel(name: str) -> str:
+    pascal = snake_to_pascal(name)
+    return pascal[:1].lower() + pascal[1:] if pascal else pascal
+
+def singularize_last_token(table: str) -> str:
+    """
+    只对最后一个 token 做很轻量的英文单数化，满足 models->model, cameras->camera
+    覆盖面不追求完美（比如 companies->company 也处理一下）。
+    """
+    toks = table.split("_")
+    if not toks:
+        return table
+    last = toks[-1]
+    if last.endswith("ies") and len(last) > 3:
+        last = last[:-3] + "y"
+    elif last.endswith("ses") and len(last) > 3:
+        # classes -> class（粗略处理）
+        last = last[:-2]
+    elif last.endswith("s") and not last.endswith("ss") and len(last) > 1:
+        last = last[:-1]
+    toks[-1] = last
+    return "_".join(toks)
+
+def table_to_entity_name(table: str) -> str:
+    return snake_to_pascal(singularize_last_token(table))
+
+def resource_path_v1(table: str) -> str:
+    # 按你要求：/api/v1/ai_models（直接用表名）
+    return f"/api/v1/{table}"

--- a/scripts/codegen/requirements.txt
+++ b/scripts/codegen/requirements.txt
@@ -1,0 +1,3 @@
+psycopg[binary]==3.3.3
+pystache==0.6.8
+python-dotenv==1.2.2

--- a/scripts/codegen/templates/Controller.mustache
+++ b/scripts/codegen/templates/Controller.mustache
@@ -1,0 +1,56 @@
+package {{package_base}}.controller;
+
+import {{package_base}}.dto.{{entity_name}}CreateDTO;
+import {{package_base}}.dto.{{entity_name}}UpdateDTO;
+import {{package_base}}.vo.{{entity_name}}VO;
+import {{package_base}}.service.{{entity_name}}Service;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name="{{entity_name}}")
+@RestController
+@RequestMapping("{{resource}}")
+@RequiredArgsConstructor
+public class {{entity_name}}Controller {
+
+    private final {{entity_name}}Service service;
+
+    @GetMapping
+    public ResponseEntity<Page<{{entity_name}}VO>> list{{entity_name}}(
+            @RequestParam(required = false) String keyword,
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable
+    ) {
+        return ResponseEntity.ok(service.list{{entity_name}}s(keyword, pageable));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<{{entity_name}}VO> get{{entity_name}}(@PathVariable Long id) {
+        return ResponseEntity.ok(service.get{{entity_name}}(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<{{entity_name}}VO> create{{entity_name}}(@RequestBody {{entity_name}}CreateDTO createDTO) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.create{{entity_name}}(createDTO));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<{{entity_name}}VO> update{{entity_name}}(
+            @PathVariable Long id,
+            @RequestBody {{entity_name}}UpdateDTO updateDTO
+    ) {
+        return ResponseEntity.ok(service.update{{entity_name}}(id, updateDTO));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete{{entity_name}}(@PathVariable Long id) {
+        service.delete{{entity_name}}(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/scripts/codegen/templates/CreateDTO.mustache
+++ b/scripts/codegen/templates/CreateDTO.mustache
@@ -1,0 +1,20 @@
+package {{package_base}}.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+
+/**
+ * DTO for {@link {{package_base}}.entity.{{entity_name}}}
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class {{entity_name}}CreateDTO implements Serializable {
+    {{#fields}}
+    private {{java_type}} {{name}};
+    {{/fields}}
+}

--- a/scripts/codegen/templates/Mapper.mustache
+++ b/scripts/codegen/templates/Mapper.mustache
@@ -1,0 +1,24 @@
+package {{package_base}}.mapper;
+
+import {{package_base}}.dto.{{entity_name}}CreateDTO;
+import {{package_base}}.dto.{{entity_name}}UpdateDTO;
+import {{package_base}}.entity.{{entity_name}};
+import {{package_base}}.vo.{{entity_name}}VO;
+import org.mapstruct.*;
+
+@Mapper(componentModel = "spring")
+public interface {{entity_name}}Mapper {
+
+    {{entity_name}}VO toVO({{entity_name}} entity);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    {{entity_name}} toEntity({{entity_name}}CreateDTO dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    void updateEntity({{entity_name}}UpdateDTO dto, @MappingTarget {{entity_name}} entity);
+}

--- a/scripts/codegen/templates/Service.mustache
+++ b/scripts/codegen/templates/Service.mustache
@@ -1,0 +1,47 @@
+package {{package_base}}.service;
+
+import {{package_base}}.dto.{{entity_name}}CreateDTO;
+import {{package_base}}.dto.{{entity_name}}UpdateDTO;
+import {{package_base}}.entity.{{entity_name}};
+import {{package_base}}.mapper.{{entity_name}}Mapper;
+import {{package_base}}.repository.{{entity_name}}Repository;
+import {{package_base}}.vo.{{entity_name}}VO;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class {{entity_name}}Service {
+
+    private final {{entity_name}}Repository repository;
+    private final {{entity_name}}Mapper mapper;
+
+    public Page<{{entity_name}}VO> list{{entity_name}}s(String keyword, Pageable pageable) {
+        return repository.findByNameContains(keyword, pageable).map(mapper::toVO);
+    }
+
+    public {{entity_name}}VO get{{entity_name}}(Long id) {
+        return repository.findById(id).map(mapper::toVO)
+                .orElseThrow(() -> new EntityNotFoundException("{{entity_name}} not found"));
+    }
+
+    public {{entity_name}}VO create{{entity_name}}({{entity_name}}CreateDTO createDTO) {
+        return mapper.toVO(repository.save(mapper.toEntity(createDTO)));
+    }
+
+    public {{entity_name}}VO update{{entity_name}}(Long id, {{entity_name}}UpdateDTO updateDTO) {
+        {{entity_name}} entity = repository.findById(id).
+                orElseThrow(() -> new EntityNotFoundException("{{entity_name}} not found"));
+        mapper.updateEntity(updateDTO, entity);
+        return mapper.toVO(repository.save(entity));
+    }
+
+    public void delete{{entity_name}}(Long id) {
+        {{entity_name}} entity = repository.findById(id).
+                orElseThrow(() -> new EntityNotFoundException("{{entity_name}} not found"));
+        repository.delete(entity);
+    }
+}

--- a/scripts/codegen/templates/UpdateDTO.mustache
+++ b/scripts/codegen/templates/UpdateDTO.mustache
@@ -1,0 +1,20 @@
+package {{package_base}}.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+
+/**
+ * DTO for {@link {{package_base}}.entity.{{entity_name}}}
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class {{entity_name}}UpdateDTO implements Serializable {
+    {{#fields}}
+    private {{java_type}} {{name}};
+    {{/fields}}
+}

--- a/scripts/codegen/templates/VO.mustache
+++ b/scripts/codegen/templates/VO.mustache
@@ -1,0 +1,14 @@
+package {{package_base}}.vo;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+
+/**
+ * VO for {@link {{package_base}}.entity.{{entity_name}}}
+ */
+public record {{entity_name}}VO(
+        {{#fields}}
+        {{java_type}} {{name}},
+        {{/fields}}
+) implements Serializable {
+}

--- a/scripts/codegen/type_map.py
+++ b/scripts/codegen/type_map.py
@@ -1,0 +1,30 @@
+def pg_to_java(data_type: str, udt_name: str | None = None) -> str:
+    """
+    data_type: information_schema.columns.data_type
+    udt_name:  information_schema.columns.udt_name (更细：如 int8、varchar、timestamptz)
+    """
+    t = (udt_name or data_type or "").lower()
+
+    mapping = {
+        "int8": "Long",
+        "bigint": "Long",
+        "int4": "Integer",
+        "integer": "Integer",
+        "int2": "Short",
+        "smallint": "Short",
+        "bool": "Boolean",
+        "boolean": "Boolean",
+        "uuid": "UUID",
+        "text": "String",
+        "varchar": "String",
+        "bpchar": "String",      # char(n)
+        "numeric": "BigDecimal",
+        "float8": "Double",
+        "float4": "Float",
+        "date": "LocalDate",
+        "timestamp": "LocalDateTime",
+        "timestamptz": "OffsetDateTime",
+        "jsonb": "JsonNode",     # 或 String
+        "json": "JsonNode",
+    }
+    return mapping.get(t, "String")


### PR DESCRIPTION
Add SQL-to-Java codegen scripts and templates

Introduce a new code generation tool under scripts/codegen that introspects a PostgreSQL schema and emits Java artifacts (DTOs, VO, Mapper, Service, Controller). Adds: introspection utilities (introspect_pg.py), data models (model.py), naming helpers (naming.py), main generator (gen.py) with dotenv-driven config and selective table generation, Mustache templates for Java files, an example .env, and requirements.txt listing dependencies (psycopg, pystache, python-dotenv). This enables generating Spring-friendly Java layers from DB tables via templates and a configurable output package path.