### PR TITLE
release: develop -> main — watchtower REPO_USER/REPO_PASS auth (ADR-0022 path A)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,10 @@ POSTGRES_PASSWORD=
 NEO4J_USERNAME=
 NEO4J_PASSWORD=
 JWT_SECRET=
+
+# GHCR pull credentials (ADR-0022 CD) — used by watchtower on the deploy host via
+# REPO_USER/REPO_PASS in docker-compose.cd.yml. Only needed on the deploy host.
+#   GHCR_USER = your GitHub username
+#   GHCR_PAT  = a classic Personal Access Token with the read:packages scope
+GHCR_USER=
+GHCR_PAT=

--- a/docker-compose.cd.yml
+++ b/docker-compose.cd.yml
@@ -43,11 +43,13 @@ services:
     build: !reset null
 
   # ── watchtower：自动拉取并重建 :prod digest 变化的服务容器 ─────────────────
-  # 监控策略：WATCHTOWER_LABEL_ENABLE=false（默认），监控同 compose 项目的所有容器。
-  # 若只想监控本栈（非 host 上其他容器），可改为 label 模式：
-  #   WATCHTOWER_LABEL_ENABLE=true
-  #   并在各服务 labels: 下加 com.centurylinklabs.watchtower.enable=true
-  # 当前选择：监控同 Docker 守护进程下的全部容器（含本栈 + watchtower 自身除外）。
+  # 认证（路 A，Windows 友好）：用 REPO_USER/REPO_PASS，从演示机的 .env 注入
+  #   （GHCR_USER=GitHub 用户名、GHCR_PAT=read:packages PAT）。.env 已被 .gitignore
+  #   忽略，不入库。这样避开 Windows Docker Desktop 把凭据存进 credsStore（而非明文
+  #   config.json）、导致挂载 config.json 拿不到凭据的坑。见 .env.example。
+  # 监控范围：WATCHTOWER_LABEL_ENABLE=false = 监控同 Docker 守护进程下全部容器。
+  #   若只想监控本栈，改 "true" 并在各服务 labels 下加
+  #   com.centurylinklabs.watchtower.enable=true。
   watchtower:
     image: containrrr/watchtower
     container_name: ai-kids-watchtower
@@ -55,16 +57,12 @@ services:
     volumes:
       # Docker socket：watchtower 用它拉取镜像并重建容器
       - /var/run/docker.sock:/var/run/docker.sock
-      # GHCR 登录凭据（host 侧先手动 docker login ghcr.io，见上方 OQ-2 说明）
-      # ${DOCKER_CONFIG:-$HOME/.docker} 允许通过环境变量覆盖路径
-      - ${DOCKER_CONFIG:-/root/.docker}/config.json:/config.json:ro
     environment:
       # 轮询间隔（秒）。300 = 每 5 分钟检查一次 :prod digest。
       WATCHTOWER_POLL_INTERVAL: "300"
       # 拉取新镜像后删除旧镜像，避免磁盘堆积
       WATCHTOWER_CLEANUP: "true"
-      # 只处理有 watchtower enable label 的容器（改为 "false" 监控全部）
-      # 当前 = "false"：监控本 Docker daemon 下所有容器
       WATCHTOWER_LABEL_ENABLE: "false"
-      # 拉取 GHCR 私有镜像时使用挂载的 config.json 凭据
-      DOCKER_CONFIG: /config.json
+      # GHCR 私有镜像拉取凭据（从演示机 .env 注入；见 .env.example）
+      REPO_USER: ${GHCR_USER:-}
+      REPO_PASS: ${GHCR_PAT:-}

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -43,17 +43,27 @@ main 打 v* tag
 
 `:<version>` 不可变，用于回滚；`:prod` 是 watchtower 轮询的可变 tag。
 
-### 演示机首次配置（维护者操作一次）
+### 演示机首次配置（维护者操作一次，Windows PowerShell）
 
-```bash
-# 1. 用 read:packages scope 的 PAT 登录 GHCR
-docker login ghcr.io -u <github-username> --password-stdin
-# 2. 启动含 watchtower 的演示栈
+```powershell
+# 1. 让 Docker Desktop 登录 GHCR（供初次 docker compose pull）。
+#    Windows 上避免 --password-stdin（PowerShell 管道喂 stdin 易卡），改用交互式：
+#    提示 Password 时粘贴 read:packages PAT。
+docker login ghcr.io -u <github-username>
+
+# 2. 在演示机仓库目录建 .env（已 gitignore），填 watchtower 的 GHCR 拉取凭据（见 .env.example）：
+#    GHCR_USER=<github-username>
+#    GHCR_PAT=<read:packages PAT>
+
+# 3. 启动含 watchtower 的演示栈
 docker compose -f docker-compose.yml -f docker-compose.cd.yml up -d
 ```
 
-> ⚠️ **OQ-2（未决）**：GHCR PAT 的发放与轮换方式（host 上如何安全存放）。
-> 当前：维护者手动 `docker login`，凭据写入 `~/.docker/config.json`，watchtower 通过挂载复用。
+> **watchtower 认证（路 A，Windows 友好）**：watchtower 经 `REPO_USER`/`REPO_PASS` 从 `.env` 的
+> `GHCR_USER`/`GHCR_PAT` 读凭据拉私有镜像——避开 Windows Docker Desktop 把 `docker login` 凭据
+> 存进 credsStore（而非明文 `~/.docker/config.json`）导致挂载 config.json 失效的坑。第 1 步的
+> `docker login` 仅供初次 `docker compose pull`；watchtower 的**自动**拉取靠 `.env`。
+> **OQ-2（未决）**：GHCR PAT 的轮换方式。
 
 ### 演示数据策略（OQ-1 已定：持久）
 


### PR DESCRIPTION
## Release: `develop` → `main` — watchtower auth via REPO_USER/REPO_PASS (path A)

Small CD-config follow-up to ADR-0022 so the **deploy host** (which tracks `main`)
can `git pull` and get the Windows-friendly watchtower auth.

### Single commit (`fc63e6e`)
- `docker-compose.cd.yml`: watchtower now authenticates to GHCR via `REPO_USER`/`REPO_PASS`
  (fed from `GHCR_USER`/`GHCR_PAT` in the host `.env`, gitignored). Removes the
  `~/.docker/config.json` bind-mount, which does not work on Windows Docker Desktop
  (credentials live in the Windows credsStore, not a plaintext config.json).
- `.env.example`: add `GHCR_USER` / `GHCR_PAT`.
- `docs/operations/deployment.md`: host setup uses interactive `docker login`
  (avoids the PowerShell `--password-stdin` hang) + the `.env`-based watchtower auth.

### Verification
- `develop`: `Compose Config` (validates base/cd/prod overlays), `Backend Java Tests`,
  `Frontend lint & build` all green. CD config / docs only — no app code.

### After merge
- On the deploy host: `git pull` (tracking `main`) → updated `docker-compose.cd.yml`,
  create `.env` with `GHCR_USER`/`GHCR_PAT`, then
  `docker compose -f docker-compose.yml -f docker-compose.cd.yml up -d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
