### PR TITLE
release: develop -> main — watchtower DOCKER_API_VERSION fix

### DIFF
--- a/docker-compose.cd.yml
+++ b/docker-compose.cd.yml
@@ -66,3 +66,7 @@ services:
       # GHCR 私有镜像拉取凭据（从演示机 .env 注入；见 .env.example）
       REPO_USER: ${GHCR_USER:-}
       REPO_PASS: ${GHCR_PAT:-}
+      # containrrr/watchtower 的内置 Docker API client 默认协商版本过旧（1.25），
+      # 新 Docker daemon（Docker Desktop/Engine 较新版）最低要求 API 1.40，会拒绝并报
+      # "client version 1.25 is too old"。强制用 1.41（≥1.40 且广泛支持）即可。
+      DOCKER_API_VERSION: "1.41"


### PR DESCRIPTION
## Release: `develop` → `main` — fix watchtower Docker API version

One-line CD fix so the deploy host's watchtower can talk to the Docker daemon.

`containrrr/watchtower` negotiates Docker API **1.25** by default; recent daemons
require a minimum of **1.40** and reject it with
`client version 1.25 is too old. Minimum supported API version is 1.40`.
Set `DOCKER_API_VERSION: "1.41"` on the watchtower service.

- Only `docker-compose.cd.yml` (watchtower env). `Compose Config` CI validates it.

### After merge
- Deploy host: `git pull` (tracking `main`) → `docker compose -f docker-compose.yml -f docker-compose.cd.yml up -d` → `docker logs ai-kids-watchtower` should poll without the API-version error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
