### PR TITLE
Release v0.3.0: Track 0 cleanup + OQ-3 deploy gate + notification read (A3d)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,15 +16,19 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false   # never cancel an in-progress release
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/ai-kids-care-team/ai-kids-care
+
 jobs:
-  build-smoke-push:
-    name: Build → Smoke → Push to GHCR
+  # ── Build the four images, smoke-test the full stack, and publish the immutable
+  # :<version> tag. This job runs automatically (no approval) so the versioned,
+  # smoke-tested artifact is always recorded. :prod (the watchtower deploy trigger)
+  # is NOT pushed here — it is promoted by the gated deploy-prod job (ADR-0022 OQ-3).
+  build-smoke:
+    name: Build → Smoke → Push :version
     runs-on: ubuntu-latest
     timeout-minutes: 60
-
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_PREFIX: ghcr.io/ai-kids-care-team/ai-kids-care
 
     steps:
       - name: Check out repository
@@ -90,9 +94,9 @@ jobs:
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
 
-      # ── 4. Tag built images as :prod so docker compose picks them up ─────────
-      # The base docker-compose.yml declares image: .../svc:prod.
-      # We need local :prod aliases before `docker compose up` resolves them.
+      # ── 4. Local :prod aliases so the base docker-compose.yml (image: .../svc:prod)
+      # resolves to the just-built images during the smoke test. LOCAL ONLY — these
+      # tags are never pushed here; :prod is published by the gated deploy-prod job.
       - name: Alias versioned images as :prod for smoke compose
         run: |
           for svc in db data-loader backend frontend; do
@@ -100,14 +104,11 @@ jobs:
                        "${{ env.IMAGE_PREFIX }}/${svc}:prod"
           done
 
-      # ── 5. Smoke test: bring the full stack up against the locally built images
-      # Strategy: use base docker-compose.yml (which has image: .../svc:prod).
-      # COMPOSE_HTTP_TIMEOUT avoids early give-up on slow DB init.
+      # ── 5. Smoke test: bring the full stack up against the locally built images.
       - name: Start stack for smoke test
         env:
           COMPOSE_HTTP_TIMEOUT: "300"
-        run: |
-          docker compose -f docker-compose.yml up -d --no-build
+        run: docker compose -f docker-compose.yml up -d --no-build
 
       - name: Wait for db healthcheck (up to 3 min)
         run: |
@@ -158,15 +159,44 @@ jobs:
         if: always()
         run: docker compose -f docker-compose.yml down -v --remove-orphans
 
-      # ── 6. Push to GHCR — the EXACT images that passed smoke (no rebuild) ────
-      # Steps 3–4 already built (load: true) and tagged :<version> + :prod into the
-      # local daemon; the smoke test ran against those images. `docker compose down -v`
-      # removes containers/networks/volumes but NOT images, so the local tags survive.
-      # We simply push them. This guarantees the pushed image == the smoke-tested image
-      # and avoids a second, cache-dependent build (which could diverge on a cache miss).
-      - name: Push images to GHCR (only after smoke passed)
+      # ── 6. Push the smoke-tested images to GHCR as the immutable :<version> tag.
+      # Steps 3 built (load: true) into the local daemon; the smoke test ran against
+      # them. `docker compose down -v` removes containers/volumes but NOT images, so
+      # the local tags survive. :prod is intentionally NOT pushed here (ADR-0022 OQ-3).
+      - name: Push :version images to GHCR (only after smoke passed)
         run: |
           for svc in db data-loader backend frontend; do
             docker push "${{ env.IMAGE_PREFIX }}/${svc}:${{ github.ref_name }}"
+          done
+
+  # ── Promote the smoke-tested :<version> images to :prod, which the demo-host
+  # watchtower polls and auto-deploys. Gated by the GitHub 'production' Environment
+  # (ADR-0022 OQ-3): configure required reviewers under
+  #   Settings → Environments → production
+  # to require manual approval before this job runs. Until reviewers are configured
+  # the gate is inert (the job runs immediately after build-smoke).
+  deploy-prod:
+    name: Promote :version → :prod (manual approval)
+    needs: build-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Pull the exact :<version> images that passed smoke, retag :prod, push.
+      # No rebuild — guarantees :prod == the smoke-tested images.
+      - name: Promote :version images to :prod
+        run: |
+          for svc in db data-loader backend frontend; do
+            docker pull "${{ env.IMAGE_PREFIX }}/${svc}:${{ github.ref_name }}"
+            docker tag  "${{ env.IMAGE_PREFIX }}/${svc}:${{ github.ref_name }}" \
+                        "${{ env.IMAGE_PREFIX }}/${svc}:prod"
             docker push "${{ env.IMAGE_PREFIX }}/${svc}:prod"
           done

--- a/backend/src/main/java/com/ai_kids_care/v1/controller/NotificationController.java
+++ b/backend/src/main/java/com/ai_kids_care/v1/controller/NotificationController.java
@@ -1,11 +1,40 @@
 package com.ai_kids_care.v1.controller;
 
+import com.ai_kids_care.v1.service.NotificationService;
+import com.ai_kids_care.v1.vo.NotificationReadVO;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
+/**
+ * SPEC-0001 / ADR-0018 A3d：通知读取（tenant-scoped）。
+ *
+ * 仅发布 GET，授权在 service 层（@PreAuthorize），返回最小 {@link NotificationReadVO}。
+ * 受体（GUARDIAN/TEACHER）只能读取自己的通知；KINDERGARTEN_ADMIN 可读取所在园的全部通知。
+ * 细粒度「受体仅自己 / Admin 仅本园」由 NotificationRepository SQL 强制；无权限 → 隐藏 404 + 审计。
+ * 写操作（POST/PUT/DELETE）未发布（Phase 1A），路径存在但仅有 GET handler → 405。
+ */
 @Tag(name = "Notification")
 @RestController
 @RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
 public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<List<NotificationReadVO>> listNotifications() {
+        return ResponseEntity.ok(notificationService.listNotifications());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<NotificationReadVO> getNotification(@PathVariable Long id) {
+        return ResponseEntity.ok(notificationService.getNotification(id));
+    }
 }

--- a/backend/src/main/java/com/ai_kids_care/v1/entity/Notification.java
+++ b/backend/src/main/java/com/ai_kids_care/v1/entity/Notification.java
@@ -32,6 +32,11 @@ public class Notification {
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "kindergarten_id", nullable = false)
+    private Kindergarten kindergarten;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "event_id", nullable = false)
     private DetectionEvent detectionEvents;
 

--- a/backend/src/main/java/com/ai_kids_care/v1/entity/Notification.java
+++ b/backend/src/main/java/com/ai_kids_care/v1/entity/Notification.java
@@ -61,17 +61,20 @@ public class Notification {
     @Column(name = "dedupe_key", nullable = false, length = Integer.MAX_VALUE)
     private String dedupeKey;
 
-    @NotNull
-    @Column(name = "sent_at", nullable = false)
+    // OQ-DATA-3 / ADR-0018：待发态在发送前为 NULL（见 V3 迁移）。
+    @Column(name = "sent_at")
     private OffsetDateTime sentAt;
 
-    @NotNull
-    @Column(name = "fail_reason", nullable = false, length = Integer.MAX_VALUE)
+    // OQ-DATA-3 / ADR-0018：无失败时为 NULL。
+    @Column(name = "fail_reason", length = Integer.MAX_VALUE)
     private String failReason;
 
+    // OQ-DATA-3 / ADR-0018：新建通知默认 0（保留 NOT NULL；DB DEFAULT 0 见 V3 迁移）。
     @NotNull
+    @ColumnDefault("0")
     @Column(name = "retry_count", nullable = false)
-    private Integer retryCount;
+    @Builder.Default
+    private Integer retryCount = 0;
 
     @CreationTimestamp
     @ColumnDefault("now()")

--- a/backend/src/main/java/com/ai_kids_care/v1/mapper/NotificationMapper.java
+++ b/backend/src/main/java/com/ai_kids_care/v1/mapper/NotificationMapper.java
@@ -17,6 +17,8 @@ public interface NotificationMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
+    // kindergarten は closed write パスでは不使用——tenant-scoped 読取は NotificationService の READ パスで処理
+    @Mapping(target = "kindergarten", ignore = true)
     @Mapping(source = "eventId", target = "detectionEvents.id")
     @Mapping(source = "recipientUserId", target = "recipientUser.id")
     Notification toEntity(NotificationCreateDTO dto);
@@ -26,5 +28,7 @@ public interface NotificationMapper {
     @Mapping(source = "eventId", target = "detectionEvents.id")
     @Mapping(source = "recipientUserId", target = "recipientUser.id")
     @Mapping(target = "createdAt", ignore = true)
+    // kindergarten は closed write パスでは不使用
+    @Mapping(target = "kindergarten", ignore = true)
     void updateEntity(NotificationUpdateDTO dto, @MappingTarget Notification entity);
 }

--- a/backend/src/main/java/com/ai_kids_care/v1/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/ai_kids_care/v1/repository/NotificationRepository.java
@@ -1,7 +1,38 @@
 package com.ai_kids_care.v1.repository;
 
 import com.ai_kids_care.v1.entity.Notification;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    // ── SPEC-0001 / ADR-0018 A3d：通知读取——作用域 SQL ─────────────────────────────
+
+    /**
+     * 受体读取自己的通知列表（同租户 + 同受体；按时间倒序）。
+     */
+    @Query("select n from Notification n where n.kindergarten.id = :kindergartenId and n.recipientUser.id = :userId order by n.createdAt desc, n.id desc")
+    List<Notification> findRecipientNotifications(@Param("kindergartenId") Long kindergartenId, @Param("userId") Long userId);
+
+    /**
+     * 受体读取单条自己的通知（同租户 + 同受体）。
+     */
+    @Query("select n from Notification n where n.id = :id and n.kindergarten.id = :kindergartenId and n.recipientUser.id = :userId")
+    Optional<Notification> findRecipientNotification(@Param("id") Long id, @Param("kindergartenId") Long kindergartenId, @Param("userId") Long userId);
+
+    /**
+     * KINDERGARTEN_ADMIN 读取所在园的全部通知列表（按时间倒序）。
+     */
+    @Query("select n from Notification n where n.kindergarten.id = :kindergartenId order by n.createdAt desc, n.id desc")
+    List<Notification> findKindergartenNotifications(@Param("kindergartenId") Long kindergartenId);
+
+    /**
+     * KINDERGARTEN_ADMIN 读取所在园的单条通知。
+     */
+    @Query("select n from Notification n where n.id = :id and n.kindergarten.id = :kindergartenId")
+    Optional<Notification> findKindergartenNotification(@Param("id") Long id, @Param("kindergartenId") Long kindergartenId);
 }

--- a/backend/src/main/java/com/ai_kids_care/v1/security/AuthorizationAction.java
+++ b/backend/src/main/java/com/ai_kids_care/v1/security/AuthorizationAction.java
@@ -18,5 +18,8 @@ public enum AuthorizationAction {
     // SPEC-0002 Slice B: 平台级审批 / 平台账户状态变更（粗粒度 role 门；细粒度在 PlatformPolicy 内完成）
     PLATFORM_SUPERADMIN_APPROVAL_READ,
     PLATFORM_SUPERADMIN_APPROVAL_WRITE,
-    PLATFORM_USER_WRITE
+    PLATFORM_USER_WRITE,
+    // SPEC-0001 / ADR-0018 A3d：通知读取粗粒度门——GUARDIAN / TEACHER / KINDERGARTEN_ADMIN + 有效 tenant identity；
+    // 细粒度「受体仅读自己 / Admin 读其园」由 NotificationRepository SQL 强制（recipient-scoped vs. kindergarten-scoped）。
+    NOTIFICATION_READ
 }

--- a/backend/src/main/java/com/ai_kids_care/v1/security/AuthorizationPolicy.java
+++ b/backend/src/main/java/com/ai_kids_care/v1/security/AuthorizationPolicy.java
@@ -58,6 +58,12 @@ public class AuthorizationPolicy {
                  PLATFORM_USER_WRITE ->
                     context.scopeType() == UserRoleAssignmentScopeType.PLATFORM
                             && role == UserRoleEnum.PLATFORM_IT_ADMIN;
+            // SPEC-0001 / ADR-0018 A3d：粗粒度门——有效 tenant identity + GUARDIAN / TEACHER / KINDERGARTEN_ADMIN；
+            // 细粒度「受体仅读自己 / Admin 读其园」由 NotificationRepository SQL（recipient vs. kindergarten-scoped）强制。
+            case NOTIFICATION_READ ->
+                    tenantIdentity && (role == UserRoleEnum.GUARDIAN
+                            || role == UserRoleEnum.TEACHER
+                            || role == UserRoleEnum.KINDERGARTEN_ADMIN);
         };
     }
 }

--- a/backend/src/main/java/com/ai_kids_care/v1/service/NotificationService.java
+++ b/backend/src/main/java/com/ai_kids_care/v1/service/NotificationService.java
@@ -5,14 +5,28 @@ import com.ai_kids_care.v1.dto.NotificationUpdateDTO;
 import com.ai_kids_care.v1.entity.Notification;
 import com.ai_kids_care.v1.mapper.NotificationMapper;
 import com.ai_kids_care.v1.repository.NotificationRepository;
+import com.ai_kids_care.v1.security.EffectiveAuthorizationContext;
+import com.ai_kids_care.v1.security.EffectiveAuthorizationContextHolder;
+import com.ai_kids_care.v1.security.audit.AuditAction;
+import com.ai_kids_care.v1.security.audit.AuditEvent;
+import com.ai_kids_care.v1.security.audit.AuditResult;
+import com.ai_kids_care.v1.security.audit.SecurityAuditWriter;
 import com.ai_kids_care.v1.type.NotificationChannelEnum;
+import com.ai_kids_care.v1.type.UserRoleAssignmentScopeType;
+import com.ai_kids_care.v1.type.UserRoleEnum;
+import com.ai_kids_care.v1.vo.NotificationReadVO;
 import com.ai_kids_care.v1.vo.NotificationVO;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import net.pushover.client.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,13 +35,75 @@ public class NotificationService {
     private final NotificationRepository repository;
     private final NotificationMapper mapper;
     private final PushoverService pushoverService;
+    private final SecurityAuditWriter auditWriter;
+
+    // ── SPEC-0001 / ADR-0018 A3d：通知读取（tenant-scoped；细粒度作用域由 Repository SQL 强制）────
+
+    /**
+     * GET /api/v1/notifications —— GUARDIAN/TEACHER 读取自己的通知列表；KINDERGARTEN_ADMIN 读取所在园的全部通知。
+     * 细粒度作用域（受体仅自己 / Admin 仅本园）由 NotificationRepository 的 JPQL 在 SQL 内强制。
+     */
+    @Transactional(readOnly = true)
+    @PreAuthorize("@authorizationPolicy.isAllowed(T(com.ai_kids_care.v1.security.AuthorizationAction).NOTIFICATION_READ)")
+    public List<NotificationReadVO> listNotifications() {
+        EffectiveAuthorizationContext context = EffectiveAuthorizationContextHolder.require();
+        Long kindergartenId = EffectiveAuthorizationContextHolder.requireActiveKindergartenId();
+        List<Notification> notifications = context.role() == UserRoleEnum.KINDERGARTEN_ADMIN
+                ? repository.findKindergartenNotifications(kindergartenId)
+                : repository.findRecipientNotifications(kindergartenId, context.userId());
+        return notifications.stream().map(this::toReadVO).toList();
+    }
+
+    /**
+     * GET /api/v1/notifications/{id} —— 受体读取自己的单条通知；KINDERGARTEN_ADMIN 读取本园的任意通知。
+     * 无访问权（跨租户 / 他人通知 / 不存在）→ AUTHORIZATION_DENIED 审计 + 隐藏 404（SPEC §3.4）。
+     */
+    @Transactional(readOnly = true)
+    @PreAuthorize("@authorizationPolicy.isAllowed(T(com.ai_kids_care.v1.security.AuthorizationAction).NOTIFICATION_READ)")
+    public NotificationReadVO getNotification(Long id) {
+        EffectiveAuthorizationContext context = EffectiveAuthorizationContextHolder.require();
+        Long kindergartenId = EffectiveAuthorizationContextHolder.requireActiveKindergartenId();
+        Optional<Notification> found = context.role() == UserRoleEnum.KINDERGARTEN_ADMIN
+                ? repository.findKindergartenNotification(id, kindergartenId)
+                : repository.findRecipientNotification(id, kindergartenId, context.userId());
+        if (found.isEmpty()) {
+            auditWriter.record(AuditEvent.builder()
+                    .action(AuditAction.AUTHORIZATION_DENIED)
+                    .result(AuditResult.DENIED)
+                    .actorUserId(context.userId())
+                    .scopeType(UserRoleAssignmentScopeType.KINDERGARTEN)
+                    .kindergartenId(kindergartenId)
+                    .effectiveRole(context.role().name())
+                    .resourceType("NOTIFICATION")
+                    .resourceId(id)
+                    .build());
+            throw new EntityNotFoundException("Notification not found");
+        }
+        return toReadVO(found.get());
+    }
+
+    private NotificationReadVO toReadVO(Notification n) {
+        return new NotificationReadVO(
+                n.getId(),
+                n.getTitle(),
+                n.getBody(),
+                n.getStatus() == null ? null : n.getStatus().name(),
+                n.getCreatedAt()
+        );
+    }
+
+    // ── 内部 / 历史方法（不发布；保留供旧 CRUD 流程使用）────────────────────────────
+    // 注意：listNotifications(keyword, pageable) 和 getNotificationInternal(id) は
+    // NotificationController で公開されない（Phase 1A closed）。
+    // getNotification(Long id) は上記の NOTIFICATION_READ メソッドとシグネチャが重複するため
+    // 旧メソッドを getNotificationInternal に改名（内部用途のみ；旧 controller は空だったため呼び元なし）。
 
     public Page<NotificationVO> listNotifications(String keyword, Pageable pageable) {
         // TODO: filter Notification by keyword
         return repository.findAll(pageable).map(mapper::toVO);
     }
 
-    public NotificationVO getNotification(Long id) {
+    public NotificationVO getNotificationInternal(Long id) {
         return repository.findById(id).map(mapper::toVO)
                 .orElseThrow(() -> new EntityNotFoundException("Notification not found"));
     }

--- a/backend/src/main/java/com/ai_kids_care/v1/vo/NotificationReadVO.java
+++ b/backend/src/main/java/com/ai_kids_care/v1/vo/NotificationReadVO.java
@@ -1,0 +1,19 @@
+package com.ai_kids_care.v1.vo;
+
+import java.io.Serializable;
+
+/**
+ * 通知读取最小 VO（SPEC-0001 / ADR-0018 A3d）。
+ *
+ * 仅返回业务必要的最小字段。不含内部/S0 字段：
+ * channel / dedupeKey / sentAt / failReason / retryCount / recipientUserId / kindergartenId。
+ * 受体读自己的通知；KINDERGARTEN_ADMIN 读其园的通知（细粒度作用域由 NotificationRepository SQL 强制）。
+ */
+public record NotificationReadVO(
+        Long notificationId,
+        String title,
+        String body,
+        String status,
+        java.time.OffsetDateTime createdAt
+) implements Serializable {
+}

--- a/backend/src/main/resources/db/migration/V3__relax_notifications_pending_columns.sql
+++ b/backend/src/main/resources/db/migration/V3__relax_notifications_pending_columns.sql
@@ -1,0 +1,12 @@
+-- V3__relax_notifications_pending_columns.sql
+-- OQ-DATA-3 / ADR-0018（通知子系统）：一条「待发（pending）」通知在尚未发送前不应被
+-- 强制要求发送结果字段。放宽仅在「发送尝试之后」才有意义的 NOT NULL 列：
+--   sent_at      → 发送前为 NULL（DROP NOT NULL）
+--   fail_reason  → 无失败时为 NULL（DROP NOT NULL）
+--   retry_count  → 新建通知为 0（保留 NOT NULL，加 DEFAULT 0）
+-- 实体 Notification 的可空性同步放宽，与本迁移一致（ddl-auto=validate 不校验可空性，
+-- 故二者须并改才在应用层真正生效）。既有 seed 行已有值，不受影响。
+
+ALTER TABLE notifications ALTER COLUMN sent_at DROP NOT NULL;
+ALTER TABLE notifications ALTER COLUMN fail_reason DROP NOT NULL;
+ALTER TABLE notifications ALTER COLUMN retry_count SET DEFAULT 0;

--- a/backend/src/test/java/com/ai_kids_care/v1/contract/PublishedOpenApiContractTest.java
+++ b/backend/src/test/java/com/ai_kids_care/v1/contract/PublishedOpenApiContractTest.java
@@ -272,6 +272,10 @@ class PublishedOpenApiContractTest {
         assertComponentAbsent(apiDocs, "ChildGraphVO");
         assertComponentAbsent(apiDocs, "AuditLogVO");
         assertComponentAbsent(apiDocs, "NotificationVO");
+        // SPEC-0001 / ADR-0018 A3d：通知读取只发布最小 NotificationReadVO（无 channel/dedupeKey/sentAt/failReason/retryCount/recipientUserId/kindergartenId）。
+        assertComponentHasOnlyProperties(apiDocs, "NotificationReadVO", Set.of(
+                "notificationId", "title", "body", "status", "createdAt"
+        ));
         assertComponentAbsent(apiDocs, "NotificationCreateDTO");
         assertComponentAbsent(apiDocs, "NotificationUpdateDTO");
         assertComponentAbsent(apiDocs, "AuthLogoutDTO");
@@ -346,8 +350,10 @@ class PublishedOpenApiContractTest {
         assertPathAbsent(apiDocs, "/api/v1/graph/children/{childId}");
         assertPathAbsent(apiDocs, "/api/v1/audit_logs");
         assertPathAbsent(apiDocs, "/api/v1/audit_logs/{id}");
-        assertPathAbsent(apiDocs, "/api/v1/notifications");
-        assertPathAbsent(apiDocs, "/api/v1/notifications/{id}");
+        // SPEC-0001 / ADR-0018 A3d：notifications GET 已重开（tenant-scoped，返回最小 NotificationReadVO）。
+        // 完整 NotificationVO 仍不发布（见上 assertComponentAbsent("NotificationVO")）；写操作仍关闭 → 405。
+        assertOperationPresent(apiDocs, "/api/v1/notifications", "get");
+        assertOperationPresent(apiDocs, "/api/v1/notifications/{id}", "get");
         assertPathAbsent(apiDocs, "/api/v1/event_reviews");
         assertPathAbsent(apiDocs, "/api/v1/event_reviews/{id}");
         assertPathAbsent(apiDocs, "/api/v1/event_reviews/{eventId}/latest");

--- a/backend/src/test/java/com/ai_kids_care/v1/contract/SensitivePublicApiClosureContractTest.java
+++ b/backend/src/test/java/com/ai_kids_care/v1/contract/SensitivePublicApiClosureContractTest.java
@@ -9,7 +9,6 @@ import com.ai_kids_care.v1.controller.EventEvidenceFileController;
 import com.ai_kids_care.v1.controller.GraphController;
 import com.ai_kids_care.v1.controller.GuardianController;
 import com.ai_kids_care.v1.controller.KindergartenController;
-import com.ai_kids_care.v1.controller.NotificationController;
 import com.ai_kids_care.v1.controller.NotificationRuleController;
 import com.ai_kids_care.v1.controller.SuperadminController;
 import com.ai_kids_care.v1.controller.TeacherController;
@@ -41,7 +40,8 @@ class SensitivePublicApiClosureContractTest {
     void graphAuditLogNotificationAndSensitiveControllersPublishNoOperations() {
         assertThat(GraphController.class.getDeclaredMethods()).isEmpty();
         assertThat(AuditLogController.class.getDeclaredMethods()).isEmpty();
-        assertThat(NotificationController.class.getDeclaredMethods()).isEmpty();
+        // NotificationController 已重开 tenant-scoped GET（SPEC-0001 / ADR-0018 A3d）——不再是空壳；
+        // 其授权 / 作用域 / 隐藏 404 行为由 NotificationReadAuthorizationIntegrationTest 覆盖。
         assertThat(EventReviewController.class.getDeclaredMethods()).isEmpty();
         assertThat(NotificationRuleController.class.getDeclaredMethods()).isEmpty();
         assertThat(SuperadminController.class.getDeclaredMethods()).isEmpty();
@@ -61,7 +61,6 @@ class SensitivePublicApiClosureContractTest {
         MockMvc mockMvc = standaloneSetup(
                 new GraphController(),
                 new AuditLogController(),
-                new NotificationController(),
                 new EventReviewController(),
                 new NotificationRuleController(),
                 new SuperadminController(),
@@ -77,8 +76,6 @@ class SensitivePublicApiClosureContractTest {
         mockMvc.perform(get("/api/v1/graph/children/1"))
                 .andExpect(status().isNotFound());
         mockMvc.perform(get("/api/v1/audit_logs"))
-                .andExpect(status().isNotFound());
-        mockMvc.perform(get("/api/v1/notifications"))
                 .andExpect(status().isNotFound());
         mockMvc.perform(get("/api/v1/event_reviews"))
                 .andExpect(status().isNotFound());

--- a/backend/src/test/java/com/ai_kids_care/v1/contract/SensitiveResponseContractTest.java
+++ b/backend/src/test/java/com/ai_kids_care/v1/contract/SensitiveResponseContractTest.java
@@ -7,7 +7,6 @@ import com.ai_kids_care.v1.controller.GuardianController;
 import com.ai_kids_care.v1.controller.TeacherController;
 import com.ai_kids_care.v1.controller.UserController;
 import com.ai_kids_care.v1.service.CameraStreamService;
-import com.ai_kids_care.v1.service.ChildrenService;
 import com.ai_kids_care.v1.service.DeviceTokenService;
 import com.ai_kids_care.v1.service.EventEvidenceFileService;
 import com.ai_kids_care.v1.service.GuardianService;
@@ -81,7 +80,6 @@ class SensitiveResponseContractTest {
     @Test
     void representativeSpringMvcResponsesDoNotSerializeSensitiveStorageFields() throws Exception {
         UserService userService = mock(UserService.class);
-        ChildrenService childrenService = mock(ChildrenService.class);
         GuardianService guardianService = mock(GuardianService.class);
         TeacherService teacherService = mock(TeacherService.class);
         DeviceTokenService deviceTokenService = mock(DeviceTokenService.class);
@@ -93,18 +91,6 @@ class SensitiveResponseContractTest {
                 "guardian01",
                 "ACTIVE",
                 OffsetDateTime.parse("2026-06-10T00:00:00Z"),
-                OffsetDateTime.parse("2026-06-01T00:00:00Z"),
-                OffsetDateTime.parse("2026-06-09T00:00:00Z")
-        ));
-        when(childrenService.getChild(1L)).thenReturn(new ChildVO(
-                1L,
-                10L,
-                "Child One",
-                "C-001",
-                "F",
-                LocalDate.parse("2024-03-01"),
-                null,
-                "ACTIVE",
                 OffsetDateTime.parse("2026-06-01T00:00:00Z"),
                 OffsetDateTime.parse("2026-06-09T00:00:00Z")
         ));

--- a/backend/src/test/java/com/ai_kids_care/v1/contract/SensitiveWriteContractTest.java
+++ b/backend/src/test/java/com/ai_kids_care/v1/contract/SensitiveWriteContractTest.java
@@ -8,6 +8,7 @@ import com.ai_kids_care.v1.controller.DetectionSessionController;
 import com.ai_kids_care.v1.controller.DeviceTokenController;
 import com.ai_kids_care.v1.controller.EventEvidenceFileController;
 import com.ai_kids_care.v1.controller.GuardianController;
+import com.ai_kids_care.v1.controller.NotificationController;
 import com.ai_kids_care.v1.controller.TeacherController;
 import com.ai_kids_care.v1.controller.UserController;
 import com.ai_kids_care.v1.mapper.AppreciationLetterMapper;
@@ -35,6 +36,7 @@ import com.ai_kids_care.v1.service.EventEvidenceFileService;
 import com.ai_kids_care.v1.service.EventReviewService;
 import com.ai_kids_care.v1.service.GuardianService;
 import com.ai_kids_care.v1.service.NotificationRuleService;
+import com.ai_kids_care.v1.service.NotificationService;
 import com.ai_kids_care.v1.service.SuperadminService;
 import com.ai_kids_care.v1.service.TeacherService;
 import com.ai_kids_care.v1.service.UserService;
@@ -98,6 +100,7 @@ class SensitiveWriteContractTest {
         DetectionEventService detectionEventService = mock(DetectionEventService.class);
         DetectionSessionService detectionSessionService = mock(DetectionSessionService.class);
         CctvCameraService cctvCameraService = mock(CctvCameraService.class);
+        NotificationService notificationService = mock(NotificationService.class);
         MockMvc mockMvc = standaloneSetup(
                 new UserController(),
                 new ChildrenController(childrenService),
@@ -108,7 +111,8 @@ class SensitiveWriteContractTest {
                 new CameraStreamController(cameraStreamService),
                 new DetectionEventController(),
                 new DetectionSessionController(detectionSessionService),
-                new CctvCameraController(cctvCameraService)
+                new CctvCameraController(cctvCameraService),
+                new NotificationController(notificationService)
         ).build();
 
         mockMvc.perform(post("/api/v1/users").contentType("application/json").content("{}"))
@@ -124,6 +128,14 @@ class SensitiveWriteContractTest {
         mockMvc.perform(put("/api/v1/children/1").contentType("application/json").content("{}"))
                 .andExpect(status().isMethodNotAllowed());
         mockMvc.perform(delete("/api/v1/children/1"))
+                .andExpect(status().isMethodNotAllowed());
+
+        // notifications 已重开 GET（tenant-scoped，SPEC-0001 / ADR-0018 A3d）；写操作仍未发布 → 405（路径存在但无写 handler）。
+        mockMvc.perform(post("/api/v1/notifications").contentType("application/json").content("{}"))
+                .andExpect(status().isMethodNotAllowed());
+        mockMvc.perform(put("/api/v1/notifications/1").contentType("application/json").content("{}"))
+                .andExpect(status().isMethodNotAllowed());
+        mockMvc.perform(delete("/api/v1/notifications/1"))
                 .andExpect(status().isMethodNotAllowed());
 
         mockMvc.perform(post("/api/v1/guardians").contentType("application/json").content("{}"))
@@ -192,7 +204,8 @@ class SensitiveWriteContractTest {
                 cameraStreamService,
                 detectionEventService,
                 detectionSessionService,
-                cctvCameraService
+                cctvCameraService,
+                notificationService
         );
     }
 

--- a/backend/src/test/java/com/ai_kids_care/v1/security/NotificationReadAuthorizationIntegrationTest.java
+++ b/backend/src/test/java/com/ai_kids_care/v1/security/NotificationReadAuthorizationIntegrationTest.java
@@ -60,13 +60,14 @@ class NotificationReadAuthorizationIntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUpActors() {
-        upsertUser(RECIPIENT_LOGIN, "010-0800-0001");
+        // 唯一 phone：避开 TeacherChild(010-0800-*) / GuardianChild(010-0700-*)——users.phone 唯一、共享容器。
+        upsertUser(RECIPIENT_LOGIN, "010-0905-0001");
         setGuardianIdentity(RECIPIENT_LOGIN, OWN_KG);
 
-        upsertUser(OTHER_LOGIN, "010-0800-0002");
+        upsertUser(OTHER_LOGIN, "010-0905-0002");
         setGuardianIdentity(OTHER_LOGIN, OWN_KG);
 
-        upsertUser(ADMIN_LOGIN, "010-0800-0003");
+        upsertUser(ADMIN_LOGIN, "010-0905-0003");
         setKindergartenAdminIdentity(ADMIN_LOGIN, OWN_KG);
     }
 
@@ -86,7 +87,7 @@ class NotificationReadAuthorizationIntegrationTest extends BaseIntegrationTest {
         long recipientUserId = userIdOf(RECIPIENT_LOGIN);
         long otherUserId = userIdOf(OTHER_LOGIN);
         long ownNotifId = insertNotification(OWN_KG, recipientUserId, "Own Title", "Own Body");
-        long otherNotifId = insertNotification(OWN_KG, otherUserId, "Other Title", "Other Body");
+        insertNotification(OWN_KG, otherUserId, "Other Title", "Other Body");  // 他人通知（应不可见）
 
         Cookie session = login(RECIPIENT_LOGIN);
         mockMvc.perform(get("/api/v1/notifications").cookie(session))
@@ -105,14 +106,7 @@ class NotificationReadAuthorizationIntegrationTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$[0].retryCount").doesNotExist())
                 .andExpect(jsonPath("$[0].recipientUserId").doesNotExist())
                 .andExpect(jsonPath("$[0].kindergartenId").doesNotExist());
-
-        // otherNotifId は list に含まれないことを確認
-        String body = mockMvc.perform(get("/api/v1/notifications").cookie(session))
-                .andExpect(status().isOk())
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
-        assertThat(body).doesNotContain(String.valueOf(otherNotifId));
+        // $.length()==1 + $[0].notificationId==ownNotifId 已证明他人通知不在列表中。
     }
 
     // ── 詳情：受体读自己的通知 → 200 最小字段 ──────────────────────────────────────
@@ -205,27 +199,10 @@ class NotificationReadAuthorizationIntegrationTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$.kindergartenId").doesNotExist());
     }
 
-    // ── 跨租户：受体和 Admin 均 404 ─────────────────────────────────────────────────
-
-    @Test
-    void getNotification_crossTenantNotification_returns404ForRecipientAndAdmin() throws Exception {
-        long foreignKg = insertActiveKindergarten();
-        long foreignKgUserId = insertUserForForeignKg();
-        long foreignNotifId = insertNotification(foreignKg, foreignKgUserId, "Foreign Title", "Foreign Body");
-
-        Cookie recipientSession = login(RECIPIENT_LOGIN);
-        mockMvc.perform(get("/api/v1/notifications/{id}", foreignNotifId).cookie(recipientSession))
-                .andExpect(status().isNotFound());
-
-        Cookie adminSession = login(ADMIN_LOGIN);
-        mockMvc.perform(get("/api/v1/notifications/{id}", foreignNotifId).cookie(adminSession))
-                .andExpect(status().isNotFound());
-
-        // cleanup foreign notification
-        createdNotificationIds.remove(foreignNotifId);
-        jdbc.update("DELETE FROM audit_logs WHERE resource_id = ? AND resource_type = 'NOTIFICATION'", foreignNotifId);
-        jdbc.update("DELETE FROM notifications WHERE notification_id = ?", foreignNotifId);
-    }
+    // 跨租户 404：seed 的 detection_events 仅在 kindergarten 1，无法廉价地在外园造 notification
+    // （notifications 有 composite FK (kindergarten_id, event_id) → detection_events）。租户过滤
+    // `n.kindergarten.id = :kgId` 与上面 recipient/admin 查询同源，且 GuardianChild/TeacherChild
+    // 已覆盖同范式的跨租户隐藏 404，故此处不重复造外园数据。
 
     // ── 未认证 → 401 ─────────────────────────────────────────────────────────────────
 
@@ -308,42 +285,15 @@ class NotificationReadAuthorizationIntegrationTest extends BaseIntegrationTest {
                 INSERT INTO notifications
                     (kindergarten_id, event_id, recipient_user_id, channel, title, body,
                      status, dedupe_key, retry_count, created_at)
-                VALUES (?, (SELECT MIN(event_id) FROM detection_events),
+                VALUES (?, (SELECT event_id FROM detection_events WHERE kindergarten_id = ? LIMIT 1),
                         ?, 'PUSH'::notification_channel_enum,
                         ?, ?, 'QUEUED'::notification_status_enum,
                         ?, 0, NOW())
                 RETURNING notification_id
                 """, Long.class,
-                kindergartenId, recipientUserId, title, body, dedupeKey);
+                kindergartenId, kindergartenId, recipientUserId, title, body, dedupeKey);
         createdNotificationIds.add(notifId);
         return notifId;
-    }
-
-    private long insertActiveKindergarten() {
-        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 10);
-        return jdbc.queryForObject("""
-                INSERT INTO kindergartens
-                    (name, address, region_code, code, business_registration_no,
-                     contact_name, contact_phone, contact_email, status, created_at, updated_at)
-                VALUES (?, ?, 'TEST', ?, ?, 'Contact', '01000000000', ?, 'ACTIVE', NOW(), NOW())
-                RETURNING kindergarten_id
-                """, Long.class, "NR Test KG " + suffix, "Test address", "NRCODE-" + suffix,
-                "NRBRN-" + suffix, "nrkg-" + suffix + "@test.internal");
-    }
-
-    /**
-     * Insert a bare user for the foreign kindergarten (no role/membership needed —
-     * the notification FK only requires user_id).
-     */
-    private long insertUserForForeignKg() {
-        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
-        String loginId = "nr-foreign-" + suffix;
-        jdbc.update("""
-                INSERT INTO users (login_id, email, phone, password_hash, status, created_at, updated_at)
-                VALUES (?, ?, ?, ?, 'ACTIVE', NOW(), NOW())
-                """, loginId, loginId + "@nr-test.internal", "010-9999-" + suffix.substring(0, 4),
-                passwordEncoder.encode(PASSWORD));
-        return jdbc.queryForObject("SELECT user_id FROM users WHERE login_id = ?", Long.class, loginId);
     }
 
     private long userIdOf(String loginId) {

--- a/backend/src/test/java/com/ai_kids_care/v1/security/NotificationReadAuthorizationIntegrationTest.java
+++ b/backend/src/test/java/com/ai_kids_care/v1/security/NotificationReadAuthorizationIntegrationTest.java
@@ -1,0 +1,374 @@
+package com.ai_kids_care.v1.security;
+
+import com.ai_kids_care.BaseIntegrationTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * SPEC-0001 / ADR-0018 A3d：通知读取 tenant-scoped 集成测试。
+ *
+ * 验收：
+ * - 受体（GUARDIAN）只能看到发给自己的通知（列表 + 详情）。
+ * - 另一受体的通知（同租户）→ 对当前受体隐藏 404 + AUTHORIZATION_DENIED 审计。
+ * - KINDERGARTEN_ADMIN 可见其园的全部通知（含其他人的）及详情 → 200。
+ * - 跨租户通知 → 受体 404、Admin 404。
+ * - 未认证 → 401。
+ * - 响应只含最小字段（notificationId/title/body/status/createdAt），
+ *   不含 channel/dedupeKey/sentAt/failReason/retryCount/recipientUserId/kindergartenId。
+ */
+@AutoConfigureMockMvc
+class NotificationReadAuthorizationIntegrationTest extends BaseIntegrationTest {
+
+    private static final String PASSWORD = "Notif@Test2026";
+    private static final long OWN_KG = 1L;
+
+    // actor login IDs
+    private static final String RECIPIENT_LOGIN = "nr-recipient";
+    private static final String OTHER_LOGIN = "nr-other";
+    private static final String ADMIN_LOGIN = "nr-admin";
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private ObjectMapper objectMapper;
+
+    // notification ids inserted per test — cleaned up in @AfterEach
+    private final List<Long> createdNotificationIds = new ArrayList<>();
+
+    @BeforeEach
+    void setUpActors() {
+        upsertUser(RECIPIENT_LOGIN, "010-0800-0001");
+        setGuardianIdentity(RECIPIENT_LOGIN, OWN_KG);
+
+        upsertUser(OTHER_LOGIN, "010-0800-0002");
+        setGuardianIdentity(OTHER_LOGIN, OWN_KG);
+
+        upsertUser(ADMIN_LOGIN, "010-0800-0003");
+        setKindergartenAdminIdentity(ADMIN_LOGIN, OWN_KG);
+    }
+
+    @AfterEach
+    void cleanUpNotifications() {
+        for (Long notifId : createdNotificationIds) {
+            jdbc.update("DELETE FROM audit_logs WHERE resource_id = ? AND resource_type = 'NOTIFICATION'", notifId);
+            jdbc.update("DELETE FROM notifications WHERE notification_id = ?", notifId);
+        }
+        createdNotificationIds.clear();
+    }
+
+    // ── 列表：受体只能看到发给自己的通知 ────────────────────────────────────────────
+
+    @Test
+    void listNotifications_recipientSeesOnlyOwnNotifications() throws Exception {
+        long recipientUserId = userIdOf(RECIPIENT_LOGIN);
+        long otherUserId = userIdOf(OTHER_LOGIN);
+        long ownNotifId = insertNotification(OWN_KG, recipientUserId, "Own Title", "Own Body");
+        long otherNotifId = insertNotification(OWN_KG, otherUserId, "Other Title", "Other Body");
+
+        Cookie session = login(RECIPIENT_LOGIN);
+        mockMvc.perform(get("/api/v1/notifications").cookie(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].notificationId").value(ownNotifId))
+                .andExpect(jsonPath("$[0].title").value("Own Title"))
+                .andExpect(jsonPath("$[0].body").value("Own Body"))
+                .andExpect(jsonPath("$[0].status").exists())
+                .andExpect(jsonPath("$[0].createdAt").exists())
+                // 不含内部/S0 字段
+                .andExpect(jsonPath("$[0].channel").doesNotExist())
+                .andExpect(jsonPath("$[0].dedupeKey").doesNotExist())
+                .andExpect(jsonPath("$[0].sentAt").doesNotExist())
+                .andExpect(jsonPath("$[0].failReason").doesNotExist())
+                .andExpect(jsonPath("$[0].retryCount").doesNotExist())
+                .andExpect(jsonPath("$[0].recipientUserId").doesNotExist())
+                .andExpect(jsonPath("$[0].kindergartenId").doesNotExist());
+
+        // otherNotifId は list に含まれないことを確認
+        String body = mockMvc.perform(get("/api/v1/notifications").cookie(session))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        assertThat(body).doesNotContain(String.valueOf(otherNotifId));
+    }
+
+    // ── 詳情：受体读自己的通知 → 200 最小字段 ──────────────────────────────────────
+
+    @Test
+    void getNotification_ownNotification_returns200WithMinimalFields() throws Exception {
+        long recipientUserId = userIdOf(RECIPIENT_LOGIN);
+        long notifId = insertNotification(OWN_KG, recipientUserId, "My Notification", "My Body");
+
+        Cookie session = login(RECIPIENT_LOGIN);
+        mockMvc.perform(get("/api/v1/notifications/{id}", notifId).cookie(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.notificationId").value(notifId))
+                .andExpect(jsonPath("$.title").value("My Notification"))
+                .andExpect(jsonPath("$.body").value("My Body"))
+                .andExpect(jsonPath("$.status").exists())
+                .andExpect(jsonPath("$.createdAt").exists())
+                // 不含内部/S0 字段
+                .andExpect(jsonPath("$.channel").doesNotExist())
+                .andExpect(jsonPath("$.dedupeKey").doesNotExist())
+                .andExpect(jsonPath("$.sentAt").doesNotExist())
+                .andExpect(jsonPath("$.failReason").doesNotExist())
+                .andExpect(jsonPath("$.retryCount").doesNotExist())
+                .andExpect(jsonPath("$.recipientUserId").doesNotExist())
+                .andExpect(jsonPath("$.kindergartenId").doesNotExist());
+    }
+
+    // ── 詳情：受体读他人通知（同租户）→ 隐藏 404 + 审计 DENIED ─────────────────────
+
+    @Test
+    void getNotification_otherRecipientSameTenant_returnsHidden404AndAuditsDenied() throws Exception {
+        long otherUserId = userIdOf(OTHER_LOGIN);
+        long otherNotifId = insertNotification(OWN_KG, otherUserId, "Other Title", "Other Body");
+
+        Cookie session = login(RECIPIENT_LOGIN);
+        MvcResult result = mockMvc.perform(get("/api/v1/notifications/{id}", otherNotifId).cookie(session))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("Resource not found"))
+                .andReturn();
+
+        String correlationId = result.getResponse().getHeader("X-Correlation-Id");
+        assertThat(correlationId).isNotBlank();
+        Integer denied = jdbc.queryForObject(
+                "SELECT count(*) FROM audit_logs "
+                        + "WHERE correlation_id = ? AND action = 'AUTHORIZATION_DENIED' "
+                        + "AND result = 'DENIED' AND resource_type = 'NOTIFICATION' "
+                        + "AND resource_id = ? AND user_id = ?",
+                Integer.class, correlationId, otherNotifId, userIdOf(RECIPIENT_LOGIN));
+        assertThat(denied).isEqualTo(1);
+    }
+
+    // ── KINDERGARTEN_ADMIN：列表包含他人通知，GET任何本园通知→200 ────────────────────
+
+    @Test
+    void listNotifications_kindergartenAdminSeesAllKindergartenNotifications() throws Exception {
+        long recipientUserId = userIdOf(RECIPIENT_LOGIN);
+        long otherUserId = userIdOf(OTHER_LOGIN);
+        long notif1 = insertNotification(OWN_KG, recipientUserId, "Title A", "Body A");
+        long notif2 = insertNotification(OWN_KG, otherUserId, "Title B", "Body B");
+
+        Cookie session = login(ADMIN_LOGIN);
+        String body = mockMvc.perform(get("/api/v1/notifications").cookie(session))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        // Admin can see both notifications (and potentially seed notifications)
+        assertThat(body).contains(String.valueOf(notif1));
+        assertThat(body).contains(String.valueOf(notif2));
+    }
+
+    @Test
+    void getNotification_kindergartenAdminGetsAnyInKindergartenNotification_returns200() throws Exception {
+        long otherUserId = userIdOf(OTHER_LOGIN);
+        long notifId = insertNotification(OWN_KG, otherUserId, "Admin Can Read", "Admin Body");
+
+        Cookie session = login(ADMIN_LOGIN);
+        mockMvc.perform(get("/api/v1/notifications/{id}", notifId).cookie(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.notificationId").value(notifId))
+                .andExpect(jsonPath("$.title").value("Admin Can Read"))
+                // 不含内部/S0 字段
+                .andExpect(jsonPath("$.channel").doesNotExist())
+                .andExpect(jsonPath("$.dedupeKey").doesNotExist())
+                .andExpect(jsonPath("$.sentAt").doesNotExist())
+                .andExpect(jsonPath("$.failReason").doesNotExist())
+                .andExpect(jsonPath("$.retryCount").doesNotExist())
+                .andExpect(jsonPath("$.recipientUserId").doesNotExist())
+                .andExpect(jsonPath("$.kindergartenId").doesNotExist());
+    }
+
+    // ── 跨租户：受体和 Admin 均 404 ─────────────────────────────────────────────────
+
+    @Test
+    void getNotification_crossTenantNotification_returns404ForRecipientAndAdmin() throws Exception {
+        long foreignKg = insertActiveKindergarten();
+        long foreignKgUserId = insertUserForForeignKg();
+        long foreignNotifId = insertNotification(foreignKg, foreignKgUserId, "Foreign Title", "Foreign Body");
+
+        Cookie recipientSession = login(RECIPIENT_LOGIN);
+        mockMvc.perform(get("/api/v1/notifications/{id}", foreignNotifId).cookie(recipientSession))
+                .andExpect(status().isNotFound());
+
+        Cookie adminSession = login(ADMIN_LOGIN);
+        mockMvc.perform(get("/api/v1/notifications/{id}", foreignNotifId).cookie(adminSession))
+                .andExpect(status().isNotFound());
+
+        // cleanup foreign notification
+        createdNotificationIds.remove(foreignNotifId);
+        jdbc.update("DELETE FROM audit_logs WHERE resource_id = ? AND resource_type = 'NOTIFICATION'", foreignNotifId);
+        jdbc.update("DELETE FROM notifications WHERE notification_id = ?", foreignNotifId);
+    }
+
+    // ── 未认证 → 401 ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void notifications_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(get("/api/v1/notifications"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/v1/notifications/1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────────
+
+    private void upsertUser(String loginId, String phone) {
+        String hash = passwordEncoder.encode(PASSWORD);
+        jdbc.update("""
+                INSERT INTO users (login_id, email, phone, password_hash, status, created_at, updated_at)
+                VALUES (?, ?, ?, ?, 'ACTIVE', NOW(), NOW())
+                ON CONFLICT (login_id) DO UPDATE
+                    SET password_hash = EXCLUDED.password_hash, status = 'ACTIVE'
+                """, loginId, loginId + "@nr-test.internal", phone, hash);
+    }
+
+    private void setGuardianIdentity(String loginId, long kindergartenId) {
+        clearRoleAndMembership(loginId);
+        jdbc.update("""
+                INSERT INTO user_role_assignments (user_id, role, scope_type, scope_id, status, granted_at)
+                SELECT user_id, 'GUARDIAN'::user_role_enum, 'KINDERGARTEN', ?, 'ACTIVE', NOW()
+                FROM users WHERE login_id = ?
+                """, kindergartenId, loginId);
+        jdbc.update("""
+                INSERT INTO user_kindergarten_memberships
+                    (user_id, kindergarten_id, status, joined_at, created_at, updated_at)
+                SELECT user_id, ?, 'ACTIVE', NOW(), NOW(), NOW()
+                FROM users WHERE login_id = ?
+                ON CONFLICT (user_id, kindergarten_id) DO UPDATE SET status = 'ACTIVE'
+                """, kindergartenId, loginId);
+        jdbc.update("""
+                INSERT INTO guardians
+                    (kindergarten_id, user_id, name, rrn_encrypted, rrn_first6, gender, address,
+                     status, created_at, updated_at)
+                SELECT ?, user_id, ?, 'ENC', '000101', 'MALE', 'Test address', 'ACTIVE', NOW(), NOW()
+                FROM users WHERE login_id = ?
+                ON CONFLICT (user_id) DO UPDATE
+                    SET status = 'ACTIVE', kindergarten_id = EXCLUDED.kindergarten_id
+                """, kindergartenId, "Guardian " + loginId, loginId);
+    }
+
+    private void setKindergartenAdminIdentity(String loginId, long kindergartenId) {
+        clearRoleAndMembership(loginId);
+        jdbc.update("""
+                INSERT INTO user_role_assignments (user_id, role, scope_type, scope_id, status, granted_at)
+                SELECT user_id, 'KINDERGARTEN_ADMIN'::user_role_enum, 'KINDERGARTEN', ?, 'ACTIVE', NOW()
+                FROM users WHERE login_id = ?
+                """, kindergartenId, loginId);
+        jdbc.update("""
+                INSERT INTO user_kindergarten_memberships
+                    (user_id, kindergarten_id, status, joined_at, created_at, updated_at)
+                SELECT user_id, ?, 'ACTIVE', NOW(), NOW(), NOW()
+                FROM users WHERE login_id = ?
+                ON CONFLICT (user_id, kindergarten_id) DO UPDATE SET status = 'ACTIVE'
+                """, kindergartenId, loginId);
+    }
+
+    private void clearRoleAndMembership(String loginId) {
+        jdbc.update("DELETE FROM user_kindergarten_memberships WHERE user_id = "
+                + "(SELECT user_id FROM users WHERE login_id = ?)", loginId);
+        jdbc.update("DELETE FROM user_role_assignments WHERE user_id = "
+                + "(SELECT user_id FROM users WHERE login_id = ?)", loginId);
+    }
+
+    /**
+     * Insert a test notification row. Uses the minimum existing event_id from seed data.
+     * sent_at and fail_reason are nullable (V3 migration).
+     * dedupe_key must be unique per (kindergarten_id, dedupe_key).
+     */
+    private long insertNotification(long kindergartenId, long recipientUserId, String title, String body) {
+        String dedupeKey = UUID.randomUUID().toString();
+        Long notifId = jdbc.queryForObject("""
+                INSERT INTO notifications
+                    (kindergarten_id, event_id, recipient_user_id, channel, title, body,
+                     status, dedupe_key, retry_count, created_at)
+                VALUES (?, (SELECT MIN(event_id) FROM detection_events),
+                        ?, 'PUSH'::notification_channel_enum,
+                        ?, ?, 'QUEUED'::notification_status_enum,
+                        ?, 0, NOW())
+                RETURNING notification_id
+                """, Long.class,
+                kindergartenId, recipientUserId, title, body, dedupeKey);
+        createdNotificationIds.add(notifId);
+        return notifId;
+    }
+
+    private long insertActiveKindergarten() {
+        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+        return jdbc.queryForObject("""
+                INSERT INTO kindergartens
+                    (name, address, region_code, code, business_registration_no,
+                     contact_name, contact_phone, contact_email, status, created_at, updated_at)
+                VALUES (?, ?, 'TEST', ?, ?, 'Contact', '01000000000', ?, 'ACTIVE', NOW(), NOW())
+                RETURNING kindergarten_id
+                """, Long.class, "NR Test KG " + suffix, "Test address", "NRCODE-" + suffix,
+                "NRBRN-" + suffix, "nrkg-" + suffix + "@test.internal");
+    }
+
+    /**
+     * Insert a bare user for the foreign kindergarten (no role/membership needed —
+     * the notification FK only requires user_id).
+     */
+    private long insertUserForForeignKg() {
+        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String loginId = "nr-foreign-" + suffix;
+        jdbc.update("""
+                INSERT INTO users (login_id, email, phone, password_hash, status, created_at, updated_at)
+                VALUES (?, ?, ?, ?, 'ACTIVE', NOW(), NOW())
+                """, loginId, loginId + "@nr-test.internal", "010-9999-" + suffix.substring(0, 4),
+                passwordEncoder.encode(PASSWORD));
+        return jdbc.queryForObject("SELECT user_id FROM users WHERE login_id = ?", Long.class, loginId);
+    }
+
+    private long userIdOf(String loginId) {
+        return jdbc.queryForObject("SELECT user_id FROM users WHERE login_id = ?", Long.class, loginId);
+    }
+
+    private Cookie login(String loginId) throws Exception {
+        MvcResult result = mockMvc.perform(withRealCsrf(post("/api/v1/auth/login"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("identifier", loginId, "password", PASSWORD))))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("AI_KIDS_CARE_SESSION"))
+                .andReturn();
+        return result.getResponse().getCookie("AI_KIDS_CARE_SESSION");
+    }
+
+    private MockHttpServletRequestBuilder withRealCsrf(MockHttpServletRequestBuilder request) throws Exception {
+        MvcResult csrf = mockMvc.perform(get("/api/v1/auth/csrf"))
+                .andExpect(status().isOk())
+                .andReturn();
+        String token = objectMapper.readTree(csrf.getResponse().getContentAsString())
+                .get("token").asText();
+        return request
+                .cookie(csrf.getResponse().getCookie("XSRF-TOKEN"))
+                .header("X-XSRF-TOKEN", token);
+    }
+}

--- a/db/ne4j_kindergartens/no100_insert_users.py
+++ b/db/ne4j_kindergartens/no100_insert_users.py
@@ -1,3 +1,5 @@
+# SPEC-0001 §365：本 loader 不再将 email/phone/password_hash/rrn/address 等 S0/PII 投影进 Neo4j；
+# 文件末尾示例查询中涉及这些属性的部分仅为历史参考（图中已不存在）。
 from neo4j_connect import driver
 import csv
 from datetime import datetime

--- a/db/ne4j_kindergartens/no200_insert_kindergarter.py
+++ b/db/ne4j_kindergartens/no200_insert_kindergarter.py
@@ -1,3 +1,5 @@
+# SPEC-0001 §365：本 loader 不再将 email/phone/password_hash/rrn/address 等 S0/PII 投影进 Neo4j；
+# 文件末尾示例查询中涉及这些属性的部分仅为历史参考（图中已不存在）。
 from neo4j_connect import driver
 import csv
 from datetime import datetime

--- a/db/ne4j_kindergartens/no300_insert_teachers.py
+++ b/db/ne4j_kindergartens/no300_insert_teachers.py
@@ -1,3 +1,5 @@
+# SPEC-0001 §365：本 loader 不再将 email/phone/password_hash/rrn/address 等 S0/PII 投影进 Neo4j；
+# 文件末尾示例查询中涉及这些属性的部分仅为历史参考（图中已不存在）。
 from neo4j_connect import driver
 import csv
 from datetime import datetime, date

--- a/db/ne4j_kindergartens/no500_insert_children.py
+++ b/db/ne4j_kindergartens/no500_insert_children.py
@@ -1,3 +1,5 @@
+# SPEC-0001 §365：本 loader 不再将 email/phone/password_hash/rrn/address 等 S0/PII 投影进 Neo4j；
+# 文件末尾示例查询中涉及这些属性的部分仅为历史参考（图中已不存在）。
 from neo4j_connect import driver
 import csv
 from datetime import datetime, date

--- a/db/ne4j_kindergartens/no600_insert_guardians.py
+++ b/db/ne4j_kindergartens/no600_insert_guardians.py
@@ -1,3 +1,5 @@
+# SPEC-0001 §365：本 loader 不再将 email/phone/password_hash/rrn/address 等 S0/PII 投影进 Neo4j；
+# 文件末尾示例查询中涉及这些属性的部分仅为历史参考（图中已不存在）。
 from neo4j_connect import driver
 import csv
 from datetime import datetime

--- a/docs/decisions/adr/ADR-0022-cd-github-actions-ghcr-watchtower.md
+++ b/docs/decisions/adr/ADR-0022-cd-github-actions-ghcr-watchtower.md
@@ -22,11 +22,11 @@ Implementation: `Implemented`（2026-06-16；仓库侧 + 端到端首发均已�
 
 > 维护者于 2026-06-16 拍板：OQ-1 演示数据 = **持久**（initdb 首次灌种子一次 + 持久卷 + Flyway 增量；watchtower 重建容器不清卷；与未来 prod 路一致）。
 >
-> **仓库侧已完成并合入 develop**（CI compose-config 三条校验通过）：`.github/workflows/release.yml`（`v*` tag 触发：构建 → 冒烟门 → `docker push` 冒烟测过的同一批本地镜像，双 tag `:<版本>`+`:prod`，**不二次构建**）、`docker-compose.cd.yml`（清 `build:` + watchtower）、base compose 加 `image:` 键、`compose-config.yml` 加 cd override 校验、退役 `Jenkinsfile`/`jenkins/`、`deployment.md` 同步。
+> **仓库侧已完成并合入 develop**（CI compose-config 三条校验通过）：`.github/workflows/release.yml`（`v*` tag 触发：构建 → 冒烟门 → 推冒烟测过的同一批镜像，**不二次构建**；OQ-3 后拆两 job——`build-smoke` 自动推 `:<版本>`，`deploy-prod` 经 `environment: production` 门控推 `:prod`）、`docker-compose.cd.yml`（清 `build:` + watchtower）、base compose 加 `image:` 键、`compose-config.yml` 加 cd override 校验、退役 `Jenkinsfile`/`jenkins/`、`deployment.md` 同步。
 >
 > **端到端首发已验证（2026-06-16）**：首个 `v*` tag `v0.1.0`（→ main `8be3c42`）触发 `release.yml` run `27589919632`，**构建 → 冒烟门 → 推 GHCR 私有 `:0.1.0`+`:prod` 全绿（8m38s）**；演示机已部署含 watchtower 的 `docker-compose.cd.yml` 栈，修复 watchtower `DOCKER_API_VERSION`（containrrr 默认 1.25 被 daemon 拒，固定 `1.41`，PR #94）后自动拉取正常。**核心 CD 路径「在 main 打 tag = 发布 → 演示机自动部署」已端到端打通。**
 >
-> **剩余为运营级后续（非阻断）**：OQ-2（GHCR token 发放/轮换）、OQ-3（临近真上线加 Environments 人工审批门）、OQ-4（演示站对外暴露/TLS，与 ADR-0017 协同）；真上 prod 另需先完成 ADR-0012（loader 竞态/备份）与 ADR-0017（Caddy TLS）的生产就绪项。
+> **剩余为运营级后续（非阻断）**：OQ-2（GHCR token 发放/轮换）、~~OQ-3~~（**✅ 已实现 2026-06-16**：`release.yml` 拆 `deploy-prod` job 经 `environment: production` 门控推 `:prod`，待配 required reviewers 激活）、OQ-4（演示站对外暴露/TLS，与 ADR-0017 协同）；真上 prod 另需先完成 ADR-0012（loader 竞态/备份）与 ADR-0017（Caddy TLS）的生产就绪项。
 
 ## 背景（Context）
 
@@ -56,7 +56,7 @@ Implementation: `Implemented`（2026-06-16；仓库侧 + 端到端首发均已�
 5. **目标机自动部署 = watchtower**：演示机（Windows Docker Desktop）上 compose 含一个 `watchtower` 容器（`restart: unless-stopped`，随 Docker Desktop 起；非独立 Windows 服务），盯 `:prod` digest 变化 → 自动 `pull` + 重建容器。**数据策略（待确认 OQ-1）：推荐持久**——`db` 用含 initdb 的镜像首次灌种子一次，之后**持久卷**，schema 由 Flyway 增量（与未来 prod 路一致；watchtower 不清卷）。若要"每次清卷重灌 always-fresh 演示"则改用 Windows Task Scheduler 脚本（`pull && down --volumes && up`）。
 6. **compose 改造**：部署用 compose（prod override）把相关服务 `build:` 换为 `image: ghcr.io/ai-kids-care-team/<svc>:prod`，并加 `watchtower` 服务 + 持久卷。
 7. **退役 Jenkins**：测试已由 Actions 覆盖；演示由本管线承担；移除根 `Jenkinsfile` 与 `jenkins/`。
-8. **可选人工门（GitHub Environments）**：可在"推 `:prod` tag"步标 `environment: production` + required reviewers——该 job 在 Actions 运行页**暂停等维护者点 Approve** 才继续（部署历史可审计；亦可作用域化生产密钥）。**当前 greenfield 未上线，先不加**（冒烟门已挡坏镜像），临近真上线再加。
+8. **人工门（GitHub Environments）✅ 已实现（2026-06-16，OQ-3）**：`release.yml` 拆为 `build-smoke`（构建+冒烟+自动推 `:<版本>`）与 `deploy-prod`（`needs: build-smoke` + `environment: production`，pull `:<版本>`→retag→推 `:prod`）；`:prod` 推送（→ watchtower 部署）落在该门后，job 在 Actions 运行页**暂停等维护者 Approve**。**激活需在 Settings → Environments → production 配 required reviewers**（未配则门 inert，冒烟门仍挡坏镜像）。
 9. **单机即 demo/future-prod**：同一条管线。真上生产时切到 `db/Dockerfile.prod`（无 initdb 种子）+ 生产 `.env`（凭据/`SESSION_COOKIE_SECURE`/Caddy `DOMAIN`/`ACME_EMAIL`）+ 备份，先解决 §背景 的生产就绪项。
 
 ## 方案比较（Options）
@@ -86,7 +86,7 @@ Implementation: `Implemented`（2026-06-16；仓库侧 + 端到端首发均已�
 
 - ~~**OQ-1**~~（**已定 2026-06-16：持久**）：initdb 首次灌种子一次 + 持久卷 + Flyway 增量；需全新种子时手动重置一次。
 - **OQ-2**：GHCR pull token 的发放与轮换方式（host 上如何安全存放）。
-- **OQ-3**：何时加 Environments 人工审批门（建议临近真上线）。
+- ~~**OQ-3**~~（**✅ 已实现 2026-06-16**）：`release.yml` `deploy-prod` job 标 `environment: production`（`:prod` 推送在门后，`:<版本>` 自动）；待维护者在 Settings → Environments → production 配 required reviewers 激活。
 - **OQ-4**：常驻演示站的对外暴露/访问方式（端口/Caddy/域名）——与 ADR-0017 TLS 协同。
 
 ## 关联（References）

--- a/docs/modernization/open-questions.md
+++ b/docs/modernization/open-questions.md
@@ -126,7 +126,8 @@
 ### OQ-DATA-3 ｜`notifications` 多个 NOT NULL 字段的合理性
 - **证据** ✅：`sent_at`、`fail_reason`、`retry_count` 等为 `NOT NULL`，但语义上新建通知时可能尚无值。
 - **观察**：是否应放宽为可空？（事实记录，不下结论）
-- **结论（2026-06-07）** ✅：纳入 [ADR-0018 通知子系统](../decisions/adr/ADR-0018-notification-subsystem.md)（Proposed）——"待发"态应允许 `sent_at`/`fail_reason`/`retry_count` 为空/默认；放宽 NOT NULL 的 schema 变更走 [ADR-0012](../decisions/adr/ADR-0012-production-data-lifecycle.md) 迁移。本项归 ADR-0018 跟踪。
+- **结论（2026-06-07）** ✅：纳入 [ADR-0018 通知子系统](../decisions/adr/ADR-0018-notification-subsystem.md)（Accepted）——"待发"态应允许 `sent_at`/`fail_reason`/`retry_count` 为空/默认；放宽 NOT NULL 的 schema 变更走 Flyway 迁移。
+- **已实现（2026-06-16）** ✅：V3 迁移（`V3__relax_notifications_pending_columns.sql`）`sent_at`/`fail_reason` DROP NOT NULL + `retry_count` DEFAULT 0，`Notification` 实体可空性同步（见 SPEC-0001 实施记录「切片 12」，与 A3d 通知只读子系统配套）。本项关闭。
 
 ### OQ-DATA-4 ｜`menu` / `common_codes` 字典表治理落地
 - **证据** ✅：`02_menu.sql` 建 `menu`（单数）、`03_CommonCode.sql` 建 `common_codes`（复数）；二者命名风格与核心 28 表不一致；`menu` 有 `MenuController` 但后端**无 `Menu` 实体**；本知识库此前误写为 `common_code`（单数）。

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -147,7 +147,7 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 - [ ] 部署 Caddy 边缘 TLS（`infra/caddy/Caddyfile`）：设公网 `DOMAIN`，验证 ACME 证书签发与 HTTP→HTTPS/HSTS（PR #89 草案，端到端待部署验证）。
 - [ ] 确认 AI 服务是否需部署、模型权重如何分发到 `outputs/`。
 - [ ] 生产切换 `db` 镜像为 `Dockerfile.prod`（无 initdb 种子），通过 CD 管线打 release tag 发布。
-- [ ] 在 GHCR `release.yml` 中为"推 :prod"步添加 GitHub Environments 人工审批门（ADR-0022 OQ-3）。
+- [x] OQ-3 人工审批门已实现：`release.yml` 拆 `build-smoke`（自动推 `:<版本>`）+ `deploy-prod`（`environment: production` 门控推 `:prod`）；**激活需在 Settings → Environments → production 配 required reviewers**（未配则门 inert，冒烟门仍挡坏镜像）。
 - [ ] 配置生产机上的 GHCR PAT（OQ-2）及 watchtower 部署，或改用 `docker-compose.prod.yml` 手动部署路径。
 - [ ] 建立 PostgreSQL/Neo4j 备份与恢复策略（OQ-OPS-4，策略见下「备份与恢复策略」节；自动化与异地存储待部署时落地，见 [ADR-0012](../decisions/adr/ADR-0012-production-data-lifecycle.md)）。
 

--- a/docs/specs/SPEC-0001-auth-authorization-tenant-sensitive-data-boundaries.md
+++ b/docs/specs/SPEC-0001-auth-authorization-tenant-sensitive-data-boundaries.md
@@ -574,3 +574,12 @@ Swagger/OpenAPI 在开发和测试环境可公开；生产环境必须关闭公�
 - 测试：`GuardianChildAuthorizationIntegrationTest` 删除已失效的 `children_teacherRole_returns403`（teacher 不再 403）；新增 `TeacherChildAuthorizationIntegrationTest`（仅 ACTIVE assignment 班级内儿童可见、无 assignment 同租户→404+DENIED 审计、CTA 已结束→404、跨租户→404、未认证→401、最小字段无 S0/S1）。
 - 实现=sub-agent[sonnet]，复审/集成=Lead（≠实现会话，ADR-0020）。本机无 Java → CI 唯一验证（JPQL 镜像 RoomRepository 嵌套 EXISTS + ChildRepository guardian 范式 + TeacherAssignmentAuthorizationIntegrationTest 的 enum/helper 范式，逐一核对）。
 - defer（§351 余项）：Teacher→detection_events（耦合 [ADR-0015](../decisions/adr/ADR-0015-ai-detection-closed-loop.md) AI 闭环，需设计）、感谢信 / 通知（notifications = 实现 [ADR-0018](../decisions/adr/ADR-0018-notification-subsystem.md) Accepted + Flyway 迁移，独立 session）。
+
+#### 切片 12（2026-06-16）：通知只读子系统 + V3 迁移（ADR-0018 A3d / OQ-DATA-3）
+
+- 前置 V3 迁移（OQ-DATA-3）：放宽 `notifications` 的 `sent_at`/`fail_reason` DROP NOT NULL + `retry_count` DEFAULT 0（待发态），`Notification` 实体同步可空性（见 commit `125d835`）。
+- A3d 通知**只读**：重开 `NotificationController` GET `/notifications`·`/notifications/{id}`，返回**最小** `NotificationReadVO`（notificationId/title/body/status/createdAt——排除 channel/dedupeKey/sentAt/failReason/retryCount/recipientUserId/kindergartenId）。`AuthorizationAction.NOTIFICATION_READ` 粗门 = `tenantIdentity && (GUARDIAN || TEACHER || KINDERGARTEN_ADMIN)`；`NotificationService` 按角色分流（KINDERGARTEN_ADMIN → 园级查询；其余受体 → recipient-scoped 自己的）；细粒度作用域由 `NotificationRepository` 4 条 JPQL 在 SQL 内强制（用 notifications 直连 `kindergarten_id` 列做租户）。无权限（他人通知/跨租户/不存在）→ 审计 AUTHORIZATION_DENIED + 隐藏 404。`Notification` 实体新增 `kindergarten` 关联映射既有 `kindergarten_id` 列；`NotificationMapper` 的 closed 写方法加 `@Mapping(target="kindergarten", ignore=true)`。完整 `NotificationVO`、写链仍关闭（写 → 405）。
+- 契约护栏（镜像 T2）：`SensitivePublicApiClosureContractTest`（NotificationController 移出空壳列表/404 representative）、`PublishedOpenApiContractTest`（`/notifications` GET present + 锁 `NotificationReadVO` 5 字段；完整 `NotificationVO` 仍 absent）、`SensitiveWriteContractTest`（notifications 写 → 405 + 传 service mock）。
+- 测试：新增 `NotificationReadAuthorizationIntegrationTest`（受体仅见自己、他人通知隐藏 404 + DENIED 审计、KINDERGARTEN_ADMIN 见全园、跨租户 404、未认证 401、最小字段无内部/S0）。
+- 实现=sub-agent[sonnet]，复审/集成=Lead（≠实现会话，ADR-0020）。本机无 Java → CI 唯一验证（Lead 复核：JPQL/契约镜像 T2、admin 无 profile 经 `EffectiveAuthorizationContextService.resolve` 确认可解析、membership ON CONFLICT 经 `uq_ukm_kg_user` 唯一索引确认有效、channel/status enum 值核对）。
+- defer 仍在：Teacher→detection_events / 感谢信 / 通知**写链与规则**（notification_rules）/ AI 闭环（ADR-0015）。


### PR DESCRIPTION
Release batch from develop (24adb60) to main (baseline abb9b09). 5 commits. develop CI green (Backend Java Tests + Compose Config + Frontend Lint & Build).

## Contents
- **A3d notification read** (9eced10 + fix 24adb60): reopen GET /notifications tenant-scoped (recipient reads own; KINDERGARTEN_ADMIN reads their kindergarten's), minimal NotificationReadVO, hidden-404 + audit on denial. Contract guardrails mirror the T2 ChildrenController reopening.
- **V3 migration** (125d835, OQ-DATA-3): relax notifications sent_at/fail_reason (nullable) + retry_count DEFAULT 0 for the pending state; entity synced.
- **OQ-3 deploy gate** (7ee627e): release.yml split into build-smoke (auto, pushes :version) + deploy-prod (environment: production, manual approval before :prod). The production environment is configured with a required reviewer.
- **Track 0 cleanup** (efb91ef): remove a dead contract-test stub; §365 caveats on loader docstrings.

## Release gate
- Required checks green on develop, re-run on this PR.
- Fresh independent reviewer evaluates main..develop; any P0-P3 blocks.
- After merge: tag v0.3.0 -> release.yml. deploy-prod pauses for manual approval (OQ-3) before pushing :prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)