### PR TITLE
fix(release): supply fail-fast compose vars to smoke-test job (v0.5.0 release fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
+    # Required fail-fast vars in docker-compose.yml (no weak defaults, SPEC-0001 N-1).
+    # The smoke step actually boots the stack, so dummy-but-valid values are required:
+    # the backend validates these at startup — RrnHashConfig/CameraStreamCryptoConfig
+    # @NotBlank, and the AES key must be a 32-byte Base64 value. Mirrors
+    # compose-config.yml; values are intentionally non-secret (smoke test only).
+    env:
+      POSTGRES_PASSWORD: ci-smoke-test
+      NEO4J_PASSWORD: ci-smoke-test
+      REDIS_PASSWORD: ci-smoke-test
+      RRN_HASH_PEPPER: test-pepper-not-secret-2026
+      AI_SERVICE_TOKEN: test-ai-service-token-not-secret-2026
+      CAMERA_STREAM_AES_KEY_V1: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v6


### PR DESCRIPTION
修复 v0.5.0 release run 在 "Start stack for smoke test" 的失败(Promote→prod 被 skip)。

## 根因
`release.yml` 的 build-smoke job 跑 `docker compose up` 时未提供任何 env,而 docker-compose.yml 的 `${POSTGRES_PASSWORD:?must be set}` / `REDIS_PASSWORD` / `RRN_HASH_PEPPER` / `AI_SERVICE_TOKEN` 等必填变量(SPEC-0001 N-1 / SEC-0026 收紧为 fail-fast)无值 → interpolation 失败。compose-config.yml 当时已同步 dummy env,release.yml 的冒烟 job 漏加 → tag release 回归(上次 v0.4.0 期 release 为绿)。

## 修复(ebb9693)
build-smoke 加 job 级 dummy env,镜像 compose-config.yml。对后端启动期校验的变量用测试配置已验证能启动的 dummy:RRN_HASH_PEPPER、AI_SERVICE_TOKEN、合法 32 字节 Base64 的 CAMERA_STREAM_AES_KEY_V1;DB/Neo4j/Redis 口令为任意非密 dummy。仅冒烟用,从不推送、无生产影响。

## 验证
`docker compose -f docker-compose.yml config -q` 带该 env → exit 0(之前在此失败)。

## 后续
合并后需在 main 重新打 tag 触发 release.yml(失败的 v0.5.0 未产出任何 artifact)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)